### PR TITLE
added libcurl4-openssl-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,8 @@ RUN set -eux; \
             libpcre3 \
             libxml2 \
             libzstd1 \
-            procps
+            procps \
+            libcurl4-openssl-dev
 
 
 RUN set -xe; \


### PR DESCRIPTION
**I had a problem building the image:**

In file included from /tmp/pear/temp/swoole/ext-src/swoole_curl.cc:17:
/tmp/pear/temp/swoole/ext-src/php_swoole_curl.h:25:10: fatal error: curl/curl.h: No such file or directory
 #include <curl/curl.h>
          ^~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:231: ext-src/swoole_curl.lo] Error 1
ERROR: `make' failed

**The solution I found was by installing libcurl4-openssl-dev**