### PR TITLE
Remove manual ADD of docker-php-extension-installer on FrankenPHP images

### DIFF
--- a/FrankenPHP.Alpine.Dockerfile
+++ b/FrankenPHP.Alpine.Dockerfile
@@ -67,8 +67,6 @@ SHELL ["/bin/sh", "-eou", "pipefail", "-c"]
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo ${TZ} > /etc/timezone
 
-ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-
 RUN apk update; \
     apk upgrade; \
     apk add --no-cache \
@@ -80,7 +78,7 @@ RUN apk update; \
     ca-certificates \
     supervisor \
     libsodium-dev \
-    # Install PHP extensions
+    # Install PHP extensions (included with dunglas/frankenphp)
     && install-php-extensions \
     bz2 \
     pcntl \

--- a/FrankenPHP.Dockerfile
+++ b/FrankenPHP.Dockerfile
@@ -68,8 +68,6 @@ SHELL ["/bin/bash", "-eou", "pipefail", "-c"]
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo ${TZ} > /etc/timezone
 
-ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-
 RUN apt-get update; \
     apt-get upgrade -yqq; \
     apt-get install -yqq --no-install-recommends --show-progress \
@@ -82,7 +80,7 @@ RUN apt-get update; \
     ca-certificates \
     supervisor \
     libsodium-dev \
-    # Install PHP extensions
+    # Install PHP extensions (included with dunglas/frankenphp)
     && install-php-extensions \
     bz2 \
     pcntl \


### PR DESCRIPTION
`install-php-extensions` comes included with various FrankenPHP images

Per: https://frankenphp.dev/docs/docker/#how-to-install-more-php-extensions

I have tested this with the alpine image, and it runs and builds just like it used to. Might be good to keep this line in for consistency across the rest of the images, but who likes an extra network call?