### PR TITLE
added git binary on apk add for composer

### DIFF
--- a/FrankenPHP.Alpine.Dockerfile
+++ b/FrankenPHP.Alpine.Dockerfile
@@ -73,6 +73,7 @@ RUN apk update; \
     curl \
     wget \
     nano \
+	git \
     ncdu \
     procps \
     ca-certificates \

--- a/FrankenPHP.Dockerfile
+++ b/FrankenPHP.Dockerfile
@@ -75,6 +75,7 @@ RUN apt-get update; \
     curl \
     wget \
     nano \
+	git \
     ncdu \
     procps \
     ca-certificates \

--- a/RoadRunner.Alpine.Dockerfile
+++ b/RoadRunner.Alpine.Dockerfile
@@ -70,6 +70,7 @@ RUN apk update; \
     curl \
     wget \
     nano \
+	git \
     ncdu \
     procps \
     ca-certificates \

--- a/RoadRunner.Dockerfile
+++ b/RoadRunner.Dockerfile
@@ -72,6 +72,7 @@ RUN apt-get update; \
     curl \
     wget \
     nano \
+	git \
     ncdu \
     procps \
     ca-certificates \

--- a/Swoole.Alpine.Dockerfile
+++ b/Swoole.Alpine.Dockerfile
@@ -70,6 +70,7 @@ RUN apk update; \
     curl \
     wget \
     nano \
+	git \
     ncdu \
     procps \
     ca-certificates \

--- a/Swoole.Dockerfile
+++ b/Swoole.Dockerfile
@@ -72,6 +72,7 @@ RUN apt-get update; \
     curl \
     wget \
     nano \
+	git \
     ncdu \
     procps \
     ca-certificates \


### PR DESCRIPTION
Hi,
in some cases composer needs GIT to download a package (for example if package is hosted on github repo without packagist distribution).
In this case composer fails with this error:

```
1.617     Failed to download package from dist.
1.617     Now trying to download from source
1.874
1.877 In GitDownloader.php line 82:
1.877
1.877   git was not found in your PATH, skipping source download
1.877
```