### PR TITLE
Added docker-compose.yml and env variable OCTANE_OPTIONS

### DIFF
--- a/deployment/octane/FrankenPHP/supervisord.frankenphp.conf
+++ b/deployment/octane/FrankenPHP/supervisord.frankenphp.conf
@@ -1,6 +1,6 @@
 [program:octane]
 process_name=%(program_name)s_%(process_num)s
-command=php %(ENV_ROOT)s/artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --admin-port=2019
+command=php %(ENV_ROOT)s/artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --admin-port=2019 %(ENV_OCTANE_OPTIONS)s
 ; command=php %(ENV_ROOT)s/artisan octane:start --server=frankenphp --host=localhost --port=443 --admin-port=2019 --https --http-redirect
 user=%(ENV_USER)s
 autostart=true

--- a/deployment/octane/RoadRunner/supervisord.roadrunner.conf
+++ b/deployment/octane/RoadRunner/supervisord.roadrunner.conf
@@ -1,6 +1,6 @@
 [program:octane]
 process_name=%(program_name)s_%(process_num)s
-command=php %(ENV_ROOT)s/artisan octane:start --server=roadrunner --host=0.0.0.0 --port=8000 --rpc-port=6001 --rr-config=%(ENV_ROOT)s/.rr.yaml
+command=php %(ENV_ROOT)s/artisan octane:start --server=roadrunner --host=0.0.0.0 --port=8000 --rpc-port=6001 --rr-config=%(ENV_ROOT)s/.rr.yaml %(ENV_OCTANE_OPTIONS)s
 user=%(ENV_USER)s
 autostart=true
 autorestart=true

--- a/deployment/octane/Swoole/supervisord.swoole.conf
+++ b/deployment/octane/Swoole/supervisord.swoole.conf
@@ -1,6 +1,6 @@
 [program:octane]
 process_name=%(program_name)s_%(process_num)s
-command=php %(ENV_ROOT)s/artisan octane:start --server=swoole --host=0.0.0.0 --port=8000
+command=php %(ENV_ROOT)s/artisan octane:start --server=swoole --host=0.0.0.0 --port=8000 %(ENV_OCTANE_OPTIONS)s
 user=%(ENV_USER)s
 autostart=true
 autorestart=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,10 @@ x-base: &base
 
 services:
   # The `<<: *base` is a YAML alias that effectively imports the `x-base` stanza above
-  php:
+  http:
     <<: *base
     ports:
-      - "8000:8000" # HTTP
+      - "${HTTP_PORT:-80}:8000" # HTTP
       #- "443:443" # HTTPS for FrankenPHP images
     environment:
       RUNNING_MIGRATIONS: 'true'
@@ -27,7 +27,7 @@ services:
     profiles:
       - !dev
 
-  php-dev:
+  http-dev:
     <<: *base
     ports:
       - "8000:8000" # HTTP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,83 @@
+# Is an "extension" because it begins with `x-`. This means that the stanza is ignored by Docker.
+# The `&base` is a YAML anchor that allows you to reference the entire stanza with `<<: *base`.
+x-base: &base
+  build:
+    context: .
+    dockerfile: RoadRunner.Alpine.Dockerfile
+  image: 'quay.io/mspintegrations/control:${TAG:-latest}'
+  restart: always
+  env_file:
+    - .env
+  depends_on:
+    - mysql
+    - redis
+
+services:
+  # The `<<: *base` is a YAML alias that effectively imports the `x-base` stanza above
+  php:
+    <<: *base
+    ports:
+      - "8000:8000" # HTTP
+      #- "443:443" # HTTPS for FrankenPHP images
+    environment:
+      RUNNING_MIGRATIONS: 'true'
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+    profiles:
+      - !dev
+
+  php-dev:
+    <<: *base
+    ports:
+      - "8000:8000" # HTTP
+    environment:
+      OCTANE_OPTIONS: "--watch"
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+      - .:/var/www/html
+    profiles:
+      - dev
+
+  horizon:
+    <<: *base
+    environment:
+      - CONTAINER_MODE=horizon
+    profiles:
+      - !dev
+
+  scheduler:
+    <<: *base
+    environment:
+      - CONTAINER_MODE=scheduler
+    profiles:
+      - !dev
+
+  redis:
+    image: redis:7-alpine
+    restart: always
+    volumes:
+      - redis_data:/data
+    profiles:
+      - dev
+      - with_redis
+
+  mysql:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+      MYSQL_DATABASE: '${DB_DATABASE}'
+    volumes:
+      - mysql_data:/var/lib/mysql
+    profiles:
+      - dev
+      - with_mysql
+
+# Volumes needed for Caddy certificates and configuration
+volumes:
+  caddy_data:
+  caddy_config:
+  redis_data:
+  mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,9 @@ services:
       - .:/var/www/html
     profiles:
       - dev
+    depends_on:
+      - mysql-dev
+      - redis-dev
 
   horizon:
     <<: *base
@@ -54,16 +57,23 @@ services:
     profiles:
       - !dev
 
-  redis:
+  redis: &redis
     image: redis:7-alpine
     restart: always
     volumes:
       - redis_data:/data
     profiles:
-      - dev
+      - !dev
       - with_redis
 
-  mysql:
+  redis-dev:
+    <<: *redis
+    ports:
+      - "63791:6379"
+    profiles:
+      - dev
+
+  mysql: &mysql
     image: mysql:8.0
     restart: always
     environment:
@@ -72,8 +82,15 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
     profiles:
-      - dev
+      - !dev
       - with_mysql
+
+  mysql-dev:
+    <<: *mysql
+    ports:
+      - "3309:3306"
+    profiles:
+      - dev
 
 # Volumes needed for Caddy certificates and configuration
 volumes:


### PR DESCRIPTION
The `docker-compose.yml` file provides services for octane, horizon, and scheduler. It also provides a Redis and a MySQL container.

When running for local development, add `COMPOSE_PROFILES=dev` to your local `.env` file. This will use the `php-dev` service instead of the `php` service (to enable `--watch` in octane). It will also disable horizon and the scheduler.

When running in production, you can leave leave `COMPOSE_PROFILES` out of your `.env` file, or you can use `COMPOSE_PROFILES=with_redis`, `COMPOSE_PROFILES=with_mysql`, or `COMPOSE_PROFILES=with_redis,with_mysql` to enable Redis and/or MySQL.

If you prefer to not add the environment variable to `.env`, you can bring the services up with a profile by using `docker compose --profile dev up`