### PR TITLE
fix cache and cache_lock table not found on first run

### DIFF
--- a/deployment/start-container
+++ b/deployment/start-container
@@ -8,14 +8,14 @@ running_migrations_and_seeders=${RUNNING_MIGRATIONS_AND_SEEDERS:-"false"}
 initialStuff() {
     echo "Container mode: $container_mode"
     
+    if [ "${running_migrations_and_seeders}" = "true" ]; then
+        echo "Running migrations and seeding database ..."
+        php artisan migrate --isolated --seed --force || php artisan migrate --seed --force
+    fi
+	
     php artisan storage:link; \
     php artisan optimize:clear; \
     php artisan optimize;
-
-    if [ "${running_migrations_and_seeders}" = "true" ]; then
-        echo "Running migrations and seeding database ..."
-        php artisan migrate --isolated --seed --force;
-    fi
 }
 
 if [ "$1" != "" ]; then


### PR DESCRIPTION
I found a problem when deploy for first run and an empty database when `CACHE_STORE=database` that fail the startup of the container.
The problem is located on deployment/start-container file, on initialStuff() function and it only happens when the database is empty / no tables.
In this case we get an error related to table not fund if we try to clear cache and optimize before full migration:

`SQLSTATE[42S02]: Base table or view not found: 1146 Table 'myapp.cache' doesn't exist`

So I placed the migrate command before the link / clear / optimize commands but I encountered a new error related to migration. In this case the switch --isolated try to query the cache store to lock the migration, but since the cache store is the database itself, it fail the migration with this new error:

`SQLSTATE[42S02]: Base table or view not found: 1146 Table 'myapp.cache_locks' doesn't exist (Connection: mysql, SQL: update `cache_locks` set `owner` = ObdieQvOl9a8Bo1v, `expiration` = 1739793453 where `key` = framework/command-migrate and (`owner` = ObdieQvOl9a8Bo1v or `expiration` <= 1739789853)) `

To avoid this problem I implemented sort of try/catch using `||` operators, in this case only for first time  when the first migrate command fail, the second run correctly.

`php artisan migrate --isolated --seed --force || php artisan migrate --seed --force`


Container log (only on first startup without a database created) will look like the following screenshot:

![immagine](https://github.com/user-attachments/assets/fc4d1d33-347b-4da3-b0c0-6433e27b0982)
