### PR TITLE
Fixed worker healthcheck

### DIFF
--- a/deployment/healthcheck
+++ b/deployment/healthcheck
@@ -23,7 +23,7 @@ elif [ "${container_mode}" = "reverb" ]; then
         exit 1
     fi
 elif [ "${container_mode}" = "worker" ]; then
-    if [ "$(supervisorctl status worker:worker_00 | awk '{print tolower($2)}')" = "running" ]; then
+    if [ "$(supervisorctl status worker:worker_0 | awk '{print tolower($2)}')" = "running" ]; then
         exit 0
     else
         echo "Healthcheck failed."


### PR DESCRIPTION
The worker healthcheck in our setup was always unhealthy.
I think this is because the name of process is incorrect.
It should be `worker:worker_0`, but it is `worker:worker_00`.
After this changes the healthcheck worked again for us.