### PR TITLE
Fixed .well-known in Caddyfile

### DIFF
--- a/deployment/octane/FrankenPHP/Caddyfile
+++ b/deployment/octane/FrankenPHP/Caddyfile
@@ -56,7 +56,7 @@
 
 		header @staticshort Cache-Control "no-cache, max-age=3600"
 
-		@rejected `path('*.bak', '*.conf', '*.dist', '*.fla', '*.ini', '*.inc', '*.inci', '*.log', '*.orig', '*.psd', '*.sh', '*.sql', '*.swo', '*.swp', '*.swop', '*/.*') && !path('*/.well-known/')`
+		@rejected `path('*.bak', '*.conf', '*.dist', '*.fla', '*.ini', '*.inc', '*.inci', '*.log', '*.orig', '*.psd', '*.sh', '*.sql', '*.swo', '*.swp', '*.swop', '*/.*') && !path('*/.well-known/*')`
 		error @rejected 401
 
 		php_server {


### PR DESCRIPTION
The exception of paths in the `.well-known` "folder" only works with a wildcard afterwards. Tested with `.well-known/security.txt`