### PR TITLE
Update Traefik to v3.6 to fix Docker API version incompatibility

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -43,7 +43,7 @@ x-base: &base
 services:
   traefik:
     profiles: [app]
-    image: traefik:v3.5
+    image: traefik:v3.6
     restart: unless-stopped
     stop_grace_period: 35s
     ulimits:


### PR DESCRIPTION
This update bumps Traefik to v3.6 to resolve the error caused by an outdated Docker API client.
The previous Traefik version used Docker API 1.24, which is no longer supported.
Upgrading to v3.6 restores compatibility with modern Docker Engine versions and prevents the following error:

`ERR Failed to retrieve information of the docker client and server host error="Error response from daemon: client version 1.24 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version" providerName=docker`