### PR TITLE
moved chown after bun run build

### DIFF
--- a/FrankenPHP.Alpine.Dockerfile
+++ b/FrankenPHP.Alpine.Dockerfile
@@ -142,7 +142,6 @@ RUN mkdir -p \
     storage/framework/testing \
     storage/logs \
     bootstrap/cache \
-    && chown -R ${USER_ID}:${GROUP_ID} ${ROOT} \
     && chmod +x /usr/local/bin/start-container /usr/local/bin/healthcheck
 
 RUN composer dump-autoload \
@@ -151,6 +150,8 @@ RUN composer dump-autoload \
     --no-dev
 
 RUN bun run build
+
+RUN chown -R ${USER_ID}:${GROUP_ID} ${ROOT}
 
 USER ${USER}
 

--- a/FrankenPHP.Dockerfile
+++ b/FrankenPHP.Dockerfile
@@ -146,7 +146,6 @@ RUN mkdir -p \
     storage/framework/{sessions,views,cache,testing} \
     storage/logs \
     bootstrap/cache \
-    && chown -R ${USER_ID}:${GROUP_ID} ${ROOT} \
     && chmod +x /usr/local/bin/start-container /usr/local/bin/healthcheck
 
 RUN composer dump-autoload \
@@ -155,6 +154,8 @@ RUN composer dump-autoload \
     --no-dev
 
 RUN bun run build
+
+RUN chown -R ${USER_ID}:${GROUP_ID} ${ROOT}
 
 USER ${USER}
 

--- a/RoadRunner.Alpine.Dockerfile
+++ b/RoadRunner.Alpine.Dockerfile
@@ -125,7 +125,6 @@ RUN mkdir -p \
     storage/framework/testing \
     storage/logs \
     bootstrap/cache \
-    && chown -R ${USER_ID}:${GROUP_ID} ${ROOT} \
     && chmod +x /usr/local/bin/start-container /usr/local/bin/healthcheck
 
 RUN composer dump-autoload \
@@ -139,6 +138,8 @@ RUN if composer show | grep spiral/roadrunner-cli >/dev/null; then \
     fi
 
 RUN bun run build
+
+RUN chown -R ${USER_ID}:${GROUP_ID} ${ROOT}
 
 USER ${USER}
 

--- a/RoadRunner.Dockerfile
+++ b/RoadRunner.Dockerfile
@@ -129,7 +129,6 @@ RUN mkdir -p \
     storage/framework/{sessions,views,cache,testing} \
     storage/logs \
     bootstrap/cache \
-    && chown -R ${USER_ID}:${GROUP_ID} ${ROOT} \
     && chmod +x /usr/local/bin/start-container /usr/local/bin/healthcheck
 
 RUN composer dump-autoload \
@@ -143,6 +142,8 @@ RUN if composer show | grep spiral/roadrunner-cli >/dev/null; then \
     fi
 
 RUN bun run build
+
+RUN chown -R ${USER_ID}:${GROUP_ID} ${ROOT}
 
 USER ${USER}
 

--- a/Swoole.Alpine.Dockerfile
+++ b/Swoole.Alpine.Dockerfile
@@ -125,7 +125,6 @@ RUN mkdir -p \
     storage/framework/testing \
     storage/logs \
     bootstrap/cache \
-    && chown -R ${USER_ID}:${GROUP_ID} ${ROOT} \
     && chmod +x /usr/local/bin/start-container /usr/local/bin/healthcheck
 
 RUN composer dump-autoload \
@@ -134,6 +133,8 @@ RUN composer dump-autoload \
     --no-dev
 
 RUN bun run build
+
+RUN chown -R ${USER_ID}:${GROUP_ID} ${ROOT}
 
 USER ${USER}
 

--- a/Swoole.Dockerfile
+++ b/Swoole.Dockerfile
@@ -129,7 +129,6 @@ RUN mkdir -p \
     storage/framework/{sessions,views,cache,testing} \
     storage/logs \
     bootstrap/cache \
-    && chown -R ${USER_ID}:${GROUP_ID} ${ROOT} \
     && chmod +x /usr/local/bin/start-container /usr/local/bin/healthcheck
 
 RUN composer dump-autoload \
@@ -138,6 +137,8 @@ RUN composer dump-autoload \
     --no-dev
 
 RUN bun run build
+
+RUN chown -R ${USER_ID}:${GROUP_ID} ${ROOT}
 
 USER ${USER}
 

--- a/static-build.Dockerfile
+++ b/static-build.Dockerfile
@@ -124,8 +124,7 @@ COPY --link . .
 RUN mkdir -p \
     storage/framework/{sessions,views,cache,testing} \
     storage/logs \
-    bootstrap/cache \
-    && chown -R ${USER_ID}:${GROUP_ID} ${ROOT}
+    bootstrap/cache
 
 RUN composer dump-autoload \
     --optimize \
@@ -133,6 +132,8 @@ RUN composer dump-autoload \
     --no-dev
 
 RUN bun run build
+
+RUN chown -R ${USER_ID}:${GROUP_ID} ${ROOT}
 
 ###########################################
 


### PR DESCRIPTION
Hi,
I found a problem with new (v6.0) release associated to this issue #184 .
Some directory on final docker build is owned by root user instead laravel user and can't be writable by laravel process.
Place the chown exactly before changing the user solve the problem.
